### PR TITLE
99 - Agregar efecto Lazy Load a imágenes

### DIFF
--- a/src/Components/Common/LazyLoadImage.js
+++ b/src/Components/Common/LazyLoadImage.js
@@ -1,7 +1,9 @@
 import { useRef, useEffect, useState } from "react";
+import { Spinner } from 'react-bootstrap';
 
 const LazyLoadImage = ({ src }) => {
   const [isInViewport, setIsInViewport] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const root = useRef();
 
@@ -11,7 +13,7 @@ const LazyLoadImage = ({ src }) => {
     obs.observe(root.current);
 
     function onIntersection(entries) {
-      const { isIntersecting }  = entries[0];
+      const { isIntersecting } = entries[0];
 
       if (isIntersecting) {
         obs.disconnect();
@@ -21,9 +23,20 @@ const LazyLoadImage = ({ src }) => {
     }
   }, []);
 
+  const onLoad = () => {
+    setIsLoading((prev) => !prev);
+  };
+
+  const stylePlaceholder = {
+    display: isLoading ? "block" : "none",
+  };
+
   return (
-    <div style={{ minHeight: "150px" }} ref={root}>
-        <img src={isInViewport ? src : null}  />
+    <div className="img-container" style={{ minHeight: "200px" }} ref={root}>
+      <Spinner style={stylePlaceholder} animation="grow" role="status">
+        <span className="visually-hidden">Loading...</span>
+      </Spinner>
+      <img src={isInViewport ? src : null} onLoad={onLoad} />
     </div>
   );
 };

--- a/src/Components/Common/LazyLoadImage.js
+++ b/src/Components/Common/LazyLoadImage.js
@@ -1,0 +1,31 @@
+import { useRef, useEffect, useState } from "react";
+
+const LazyLoadImage = ({ src }) => {
+  const [isInViewport, setIsInViewport] = useState(false);
+
+  const root = useRef();
+
+  useEffect(() => {
+    const obs = new IntersectionObserver(onIntersection, { threshold: 0 });
+
+    obs.observe(root.current);
+
+    function onIntersection(entries) {
+      const { isIntersecting }  = entries[0];
+
+      if (isIntersecting) {
+        obs.disconnect();
+      }
+
+      setIsInViewport(isIntersecting);
+    }
+  }, []);
+
+  return (
+    <div style={{ minHeight: "150px" }} ref={root}>
+        <img src={isInViewport ? src : null}  />
+    </div>
+  );
+};
+
+export default LazyLoadImage;


### PR DESCRIPTION
[Link](https://alkemy-labs.atlassian.net/browse/OT143-99?atlOrigin=eyJpIjoiNmYwMTNmYTFiNTE3NGY5NTlhZjg4YTg4YWYzOTVjOGEiLCJwIjoiaiJ9)

Descripcion:

-Componente lazy load para imagenes que recibe la prop "src" para la url del tag img, el cual carga la imagen si ésta misma se encuentra en el viewport.
-el div contenedor tiene un min-height de 150px, porque sino al cargar, las imagenes tienen 0x0px, lo que hacen que esten siempre en el viewport y el componente no tendria utilidad.